### PR TITLE
Exiting the context manager cleans up files in tmp

### DIFF
--- a/scGeneFit/data_files/__init__.py
+++ b/scGeneFit/data_files/__init__.py
@@ -7,5 +7,6 @@ except ImportError:
     import importlib_resources
 
 def get_data(filename):
-    with importlib_resources.path(__name__, filename) as foo:
+    src = importlib_resources.files(__name__).joinpath(filename)
+    with importlib_resources.as_file(src) as foo:
         return scipy.io.loadmat(str(foo))

--- a/scGeneFit/data_files/__init__.py
+++ b/scGeneFit/data_files/__init__.py
@@ -1,4 +1,5 @@
 
+import scipy.io
 try:
     import importlib.resources as importlib_resources
 except ImportError:
@@ -7,4 +8,4 @@ except ImportError:
 
 def get_data(filename):
     with importlib_resources.path(__name__, filename) as foo:
-        return str(foo)
+        return scipy.io.loadmat(str(foo))

--- a/scGeneFit/functions.py
+++ b/scGeneFit/functions.py
@@ -358,7 +358,7 @@ class __ScGeneInstance:
 
 def load_example_data(name):
     if name=="CITEseq":
-        a = scipy.io.loadmat(data_files.get_data("CITEseq.mat"))
+        a = data_files.get_data("CITEseq.mat")
         data= a['G'].T
         N,d=data.shape
         #transformation from integer entries 
@@ -366,32 +366,32 @@ def load_example_data(name):
         for i in range(N):
             data[i,:]=data[i,:]/np.linalg.norm(data[i,:])
         #load labels from file
-        a = scipy.io.loadmat(data_files.get_data("CITEseq-labels.mat"))
+        a = data_files.get_data("CITEseq-labels.mat")
         l_aux = a['labels']
         labels = np.array([i for [i] in l_aux])
         #load names from file
-        a = scipy.io.loadmat(data_files.get_data("CITEseq_names.mat"))
+        a = data_files.get_data("CITEseq_names.mat")
         names=[a['citeseq_names'][i][0][0] for i in range(N)]
         return [data, labels, names]
     elif name=="zeisel":
         #load data from file
-        a = scipy.io.loadmat(data_files.get_data("zeisel_data.mat"))
+        a = data_files.get_data("zeisel_data.mat")
         data= a['zeisel_data'].T
         N,d=data.shape
 
         #load labels (first level of the hierarchy) from file
-        a = scipy.io.loadmat(data_files.get_data("zeisel_labels1.mat"))
+        a = data_files.get_data("zeisel_labels1.mat")
         l_aux = a['zeisel_labels1']
         l_0=[l_aux[i][0] for i in range(l_aux.shape[0])]
         #load labels (second level of the hierarchy) from file
-        a = scipy.io.loadmat(data_files.get_data("zeisel_labels2.mat"))
+        a = data_files.get_data("zeisel_labels2.mat")
         l_aux = a['zeisel_labels2']
         l_1=[l_aux[i][0] for i in range(l_aux.shape[0])]
         #construct an array with hierarchy labels
         labels=np.array([l_0, l_1])
 
         # load names from file 
-        a = scipy.io.loadmat(data_files.get_data("zeisel_names.mat"))
+        a = data_files.get_data("zeisel_names.mat")
         names0=[a['zeisel_names'][i][0][0] for i in range(N)]
         names1=[a['zeisel_names'][i][1][0] for i in range(N)]
         return [data, labels, [names0,names1]]


### PR DESCRIPTION
Hi!

According to https://docs.python.org/3.11/library/importlib.resources.html, "Exiting the context manager cleans up any temporary file created when the resource was extracted from e.g. a zip file.". With versions of python >3.7, this makes it impossible to return just the string of the path, as it will be sth in `/tmp` folder that would get deleted. Therefore loading the matlab data was moved inside the context manager. The `.path` paradigm is also being deprecated as of version 3.11, so I used the files/as_file approach given here https://importlib-resources.readthedocs.io/en/latest/using.html

The changes were tested with the 2 smaller scale jupyter examples. 
![image](https://user-images.githubusercontent.com/8327849/175950617-df5b2f53-6c35-4470-885d-4e673e8c5a5e.png)
![image](https://user-images.githubusercontent.com/8327849/175950693-6debff87-55e4-48b5-af72-b20fb5aa15c7.png)

It does seem to work. (And theoretically, the below PR only touches dataloading).